### PR TITLE
Support more cases in ipynb

### DIFF
--- a/Test Notebook.ipynb
+++ b/Test Notebook.ipynb
@@ -197,6 +197,29 @@
    "source": [
     "df = DataFrame((col1 = [\"First\", \"Second\", \"Third\"], col2 = [1, 2, 3]))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b565b69",
+   "metadata": {},
+   "source": [
+    "More formatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9274577c",
+   "metadata": {},
+   "source": [
+    "*Emph* **strong**\n",
+    "```\n",
+    "embeded code block\n",
+    "```\n",
+    "\n",
+    "Hard break\n",
+    "\n",
+    "Soft break    should all work"
+   ]
   }
  ],
  "metadata": {

--- a/bin/Typst_of_notebook.ml
+++ b/bin/Typst_of_notebook.ml
@@ -73,8 +73,11 @@ let output_to_typst ({ buf; _ } as ctx) = function
         (Sequence.intersperse ~sep:"\n" @@ Sequence.of_list traceback);
       Buffer.add_string buf "\n```\n])";
       []
-  | Code.DisplayData { data; meta } -> []
-  | Code.Stream { name; text } -> []
+  | Code.DisplayData { data; meta } ->
+      Option.to_list @@ extract_code_outputs ctx buf data
+  | Code.Stream { name; text } ->
+      Buffer.add_string buf text;
+      []
 
 let cell_to_typst ({ buf; _ } as ctx) lang = function
   | Markdown md ->

--- a/bin/Typst_of_notebook.ml
+++ b/bin/Typst_of_notebook.ml
@@ -112,11 +112,12 @@ let cell_to_typst ({ buf; _ } as ctx) lang = function
         else None
       in
       (* Render execution count as blue [number] and the code to the right of it. *)
-      let cell_text = Printf.sprintf {|
+      let cell_text =
         Printf.sprintf {|#exec_count("%d")
 #codeblock([%s])
 |} cd.execount
-          source in
+          source
+      in
       (* Render the output, if there is output. *)
       let result_box, attachments =
         match result with

--- a/bin/Typst_of_notebook.ml
+++ b/bin/Typst_of_notebook.ml
@@ -113,8 +113,10 @@ let cell_to_typst ({ buf; _ } as ctx) lang = function
       in
       (* Render execution count as blue [number] and the code to the right of it. *)
       let cell_text = Printf.sprintf {|
+        Printf.sprintf {|#exec_count("%d")
 #codeblock([%s])
-|} source in
+|} cd.execount
+          source in
       (* Render the output, if there is output. *)
       let result_box, attachments =
         match result with

--- a/bin/Typst_of_notebook.ml
+++ b/bin/Typst_of_notebook.ml
@@ -73,7 +73,8 @@ let output_to_typst ({ buf; _ } as ctx) = function
         (Sequence.intersperse ~sep:"\n" @@ Sequence.of_list traceback);
       Buffer.add_string buf "\n```\n])";
       []
-  | _ -> raise Unimplemented
+  | Code.DisplayData { data; meta } -> []
+  | Code.Stream { name; text } -> []
 
 let cell_to_typst ({ buf; _ } as ctx) lang = function
   | Markdown md ->

--- a/bin/Typst_of_notebook.ml
+++ b/bin/Typst_of_notebook.ml
@@ -112,12 +112,9 @@ let cell_to_typst ({ buf; _ } as ctx) lang = function
         else None
       in
       (* Render execution count as blue [number] and the code to the right of it. *)
-      let cell_text =
-        Printf.sprintf {|#exec_count("%d")
+      let cell_text = Printf.sprintf {|
 #codeblock([%s])
-|} cd.execount
-          source
-      in
+|} source in
       (* Render the output, if there is output. *)
       let result_box, attachments =
         match result with

--- a/bin/Typst_of_notebook.ml
+++ b/bin/Typst_of_notebook.ml
@@ -150,7 +150,8 @@ let nb_to_typst ?(asset_path = "typstofjupyter_assets") ~header
     match
       extract (path [ "kernel_spec"; "language" ] string) (`Assoc nb.meta)
     with
-    | Error _ -> extract_exn (path [ "language_info"; "name" ] string) (`Assoc nb.meta)
+    | Error _ ->
+        extract_exn (path [ "language_info"; "name" ] string) (`Assoc nb.meta)
     | Ok v -> v
   in
   let buf = Buffer.create 4096 in

--- a/lib/Typst.ml
+++ b/lib/Typst.ml
@@ -36,7 +36,11 @@ let rec inline_to_typst buf = function
       raise
         (Markdown_to_typst_mismatch
            "HTML content cannot be easily converted to Typst markup.")
-  | _ -> raise Unimplemented
+  | Emph _ -> ()
+  | Strong _ -> ()
+  | Code _ -> ()
+  | Hard_break _ -> ()
+  | Soft_break _ -> ()
 
 let markdown_to_typst (md : doc) =
   let buf = Buffer.create 1024 in

--- a/lib/Typst.ml
+++ b/lib/Typst.ml
@@ -39,8 +39,14 @@ let rec inline_to_typst buf = function
       raise
         (Markdown_to_typst_mismatch
            "HTML content cannot be easily converted to Typst markup.")
-  | Emph _ -> ()
-  | Strong _ -> ()
+  | Emph (_attr, inl) ->
+      Buffer.add_string buf "_";
+      inline_to_typst buf inl;
+      Buffer.add_string buf "_"
+  | Strong (_attr, inl) ->
+      Buffer.add_string buf "*";
+      inline_to_typst buf inl;
+      Buffer.add_string buf "*"
   | Code _ -> ()
   | Hard_break _ -> ()
   | Soft_break _ -> ()

--- a/lib/Typst.ml
+++ b/lib/Typst.ml
@@ -7,7 +7,10 @@ open Omd
 exception Markdown_to_typst_mismatch of string
 
 let rec inline_to_typst buf = function
-  | Text (_attr, text) -> Buffer.add_string buf text
+  | Text (_attr, text) ->
+      let escaped_txt = Str.global_replace (Str.regexp "\\$\\") "$" text in
+      let escaped_txt = Str.global_replace (Str.regexp "@") "\\@" escaped_txt in
+      Buffer.add_string buf escaped_txt
   | Concat (_attr, inls) -> List.iter ~f:(inline_to_typst buf) inls
   | Image (_attr, { label; destination; title }) ->
       let label =

--- a/lib/dune
+++ b/lib/dune
@@ -1,35 +1,36 @@
 (library
  (name typst)
  (modules Typst)
- (libraries util
- base omd))
+ (libraries util base omd str))
 
 (library
  (name util)
  (modules Util)
- (preprocess (pps ppx_inline_test ppx_sexp_value))
+ (preprocess
+  (pps ppx_inline_test ppx_sexp_value))
  (inline_tests)
  (libraries base yojson))
 
 (library
  (name notebook)
  (modules Notebook)
- (preprocess (pps ppx_inline_test ppx_sexp_value))
+ (preprocess
+  (pps ppx_inline_test ppx_sexp_value))
  (inline_tests)
- (libraries json_get util
-  base base64 core omd yojson parsexp ppx_sexp_value))
+ (libraries json_get util base base64 core omd yojson parsexp ppx_sexp_value))
 
 (library
  (name texmath)
  (modules texmath)
- (preprocess (pps ppx_inline_test ppx_expect ppx_sexp_conv))
+ (preprocess
+  (pps ppx_inline_test ppx_expect ppx_sexp_conv))
  (inline_tests)
  (libraries base core angstrom))
 
 (library
-  (name json_get)
-  (modules Json_get Json_util)
-  (preprocess (pps ppx_expect ppx_let ppx_sexp_value ppx_sexp_conv))
-  (inline_tests)
-  (libraries base core yojson)
-  )
+ (name json_get)
+ (modules Json_get Json_util)
+ (preprocess
+  (pps ppx_expect ppx_let ppx_sexp_value ppx_sexp_conv))
+ (inline_tests)
+ (libraries base core yojson))

--- a/lib/tests/Notebook_parse_test.ml
+++ b/lib/tests/Notebook_parse_test.ml
@@ -99,7 +99,7 @@ let test_outputs =
       "evalue" : "some-value",
       "traceback" : ["Trace", "Trace", "Trace"]
   }
-  
+
   |};
   ]
 
@@ -227,5 +227,11 @@ let%expect_test _ =
                  "   1 \226\148\130 First       1\n"
                  "   2 \226\148\130 Second      2\n"
                  "   3 \226\148\130 Third       3"))))
-             (meta ())))))))))) |}]
-  
+             (meta ())))))))
+       (markdown
+        ((meta ()) (attachments ()) (source ((paragraph "More formatting")))))
+       (markdown
+        ((meta ()) (attachments ())
+         (source
+          ((paragraph (concat (emph Emph) " " (strong strong))) (code-block)
+           (paragraph "Hard break") (paragraph "Soft break    should all work")))))))) |}]


### PR DESCRIPTION
Add support for code block when it is:
* Code.DisplayData
* Code.Stream

Escape: $ and @ in text

Avoid raising unimplemented error if markdown cell contains:
* Emph
* Strong
* Code
* Hard_break
* Soft_break

And it seems to work even no implementation written???
